### PR TITLE
Validate Bird config before writing it

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -193,3 +193,15 @@ A string that will be used for the bird6 config file
 
 Default value: `undef`
 
+##### `v4_path`
+
+Data type: `Stdlib::Absolutepath`
+
+Path to the bird binary
+
+##### `v6_path`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Optional path to the bird6 binary. Only set on legacy operating systems that run bird1
+

--- a/data/Archlinux.yaml
+++ b/data/Archlinux.yaml
@@ -2,3 +2,5 @@
 bird::config_path_v4: '/etc/bird.conf'
 bird::config_path_v6: '/etc/bird.conf'
 bird::package_name_v6: 'bird'
+bird::v4_path: '/usr/bin/bird'
+bird::v6_path: ~

--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -2,3 +2,5 @@
 bird::config_path_v4: '/etc/bird/bird.conf'
 bird::config_path_v6: '/etc/bird/bird6.conf'
 bird::package_name_v6: 'bird'
+bird::v4_path: '/usr/sbin/bird'
+bird::v6_path: '/usr/sbin/bird6'

--- a/data/RedHat-6.yaml
+++ b/data/RedHat-6.yaml
@@ -1,0 +1,3 @@
+---
+bird::v4_path: '/usr/sbin/bird'
+bird::v6_path: '/usr/sbin/bird6'

--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -2,3 +2,5 @@
 bird::config_path_v4: '/etc/bird.conf'
 bird::config_path_v6: '/etc/bird6.conf'
 bird::package_name_v6: 'bird6'
+bird::v4_path: '/usr/sbin/bird'
+bird::v6_path: ~

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -6,5 +6,7 @@ defaults:
   data_hash: 'yaml_data'
 
 hierarchy:
+  - name: 'Major Version'
+    path: "%{facts.os.family}-%{facts.os.release.major}.yaml"
   - name: 'Operating System Family'
     path: '%{facts.os.family}.yaml'

--- a/spec/classes/bird_spec.rb
+++ b/spec/classes/bird_spec.rb
@@ -96,7 +96,8 @@ describe 'bird' do
             enable_v6:       true,
             config_file_v6:  'puppet:///modules/fooboozoo6',
             manage_conf: true,
-            manage_service: true
+            manage_service: true,
+            v6_path: '/usr/sbin/bird6'
           }
         end
 
@@ -211,8 +212,8 @@ describe 'bird' do
               config_content_v4: 'awesome bird configuration is expected here',
               config_content_v6: 'awesome bird configuration is expected here',
               enable_v6: true,
-              manage_conf: true
-
+              manage_conf: true,
+              v6_path: '/usr/sbin/bird6'
             }
           end
 
@@ -256,17 +257,6 @@ describe 'bird' do
 
           it { is_expected.to compile.and_raise_error(%r{either config_file_v4 or config_template_v4 or config_content_v4 parameter must be set}) }
         end
-        context 'with config_template_v4 and config_content_v4' do
-          let(:params) do
-            {
-              config_template_v4: '/path/to/file',
-              config_content_v4: 'content',
-              manage_conf: true
-            }
-          end
-
-          it { is_expected.to compile.and_raise_error(%r{either config_file_v4 or config_template_v4 or config_content_v4 parameter must be set}) }
-        end
         context 'with config_file_v6 and config_template_v6' do
           let(:params) do
             {
@@ -274,33 +264,8 @@ describe 'bird' do
               config_file_v6: '/path/to/file',
               config_template_v6: 'something',
               manage_conf: true,
-              enable_v6: true
-            }
-          end
-
-          it { is_expected.to compile.and_raise_error(msg) }
-        end
-        context 'with config_file_v6 and config_content_v6' do
-          let(:params) do
-            {
-              config_file_v4: 'puppet:///modules/fooboozoo',
-              config_file_v6: '/path/to/file',
-              config_content_v6: 'content',
-              manage_conf: true,
-              enable_v6: true
-            }
-          end
-
-          it { is_expected.to compile.and_raise_error(msg) }
-        end
-        context 'with config_template_v6 and config_content_v6' do
-          let(:params) do
-            {
-              config_file_v4: 'puppet:///modules/fooboozoo',
-              config_template_v6: '/path/to/file',
-              config_content_v6: 'content',
-              manage_conf: true,
-              enable_v6: true
+              enable_v6: true,
+              v6_path: '/usr/sbin/bird6'
             }
           end
 
@@ -316,7 +281,8 @@ describe 'bird' do
             manage_conf: true,
             manage_service: true,
             service_v6_enable: true,
-            service_v4_enable: true
+            service_v4_enable: true,
+            v6_path: '/usr/sbin/bird'
           }
         end
 


### PR DESCRIPTION
Our bird configuration is templated. In case we break the config file
during a puppet run, we should not deploy it. with the validate_cmd we
can ensure that it works.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
