### PR TITLE
Use service status command to determine of bird is running

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,7 +125,6 @@ class bird (
       enable     => $service_v4_enable,
       hasrestart => false,
       restart    => '/usr/sbin/birdc configure',
-      hasstatus  => false,
       pattern    => $daemon_name_v4,
       require    => Package[$package_name_v4];
     }

--- a/spec/classes/bird_spec.rb
+++ b/spec/classes/bird_spec.rb
@@ -44,7 +44,6 @@ describe 'bird' do
         it {
           is_expected.to contain_service('bird').with(
             'ensure'     => 'running',
-            'hasstatus'  => 'false',
             'pattern'    => 'bird',
             'hasrestart' => 'false',
             'restart'    => '/usr/sbin/birdc configure'
@@ -64,7 +63,6 @@ describe 'bird' do
             is_expected.to contain_service('bird').with(
               'ensure'     => 'stopped',
               'enable'     => 'false',
-              'hasstatus'  => 'false',
               'pattern'    => 'bird',
               'hasrestart' => 'false',
               'restart'    => '/usr/sbin/birdc configure'
@@ -110,7 +108,6 @@ describe 'bird' do
         it {
           is_expected.to contain_service('bird').with(
             'ensure'     => 'running',
-            'hasstatus'  => 'false',
             'pattern'    => 'bird',
             'hasrestart' => 'false',
             'restart'    => '/usr/sbin/birdc configure'
@@ -129,7 +126,6 @@ describe 'bird' do
         it {
           is_expected.to contain_service('bird6').with(
             'ensure'     => 'running',
-            'hasstatus'  => 'false',
             'pattern'    => 'bird6',
             'hasrestart' => 'false',
             'restart'    => '/usr/sbin/birdc6 configure'
@@ -165,7 +161,6 @@ describe 'bird' do
             is_expected.to contain_service('bird').with(
               'ensure'     => 'stopped',
               'enable'     => 'false',
-              'hasstatus'  => 'false',
               'pattern'    => 'bird',
               'hasrestart' => 'false',
               'restart'    => '/usr/sbin/birdc configure'
@@ -175,7 +170,6 @@ describe 'bird' do
             is_expected.to contain_service('bird6').with(
               'ensure'     => 'stopped',
               'enable'     => 'false',
-              'hasstatus'  => 'false',
               'pattern'    => 'bird6',
               'hasrestart' => 'false',
               'restart'    => '/usr/sbin/birdc6 configure'


### PR DESCRIPTION
if hasstatus is set to false, Puppet will parse `ps` for the process.
The init scripts and also the systemd unit files have a status option,
so we should use that.

The default value is true since Puppet 2.7.0. So we don't need to
explicitly write it into the code.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
