### PR TITLE
allow `require` metaparam for bird::snippet

### DIFF
--- a/manifests/snippet.pp
+++ b/manifests/snippet.pp
@@ -31,12 +31,12 @@ define bird::snippet (
   if $manage_v6 {
     $additional_config_path = $bird::additional_config_path_v6
     $validate_cmd = "${bird::v6_path} -p -c ${bird::config_path_v6}"
-    $require = File[$bird::config_path_v6]
+    $require_filepath = File[$bird::config_path_v6]
     $daemon_name = Service[$bird::daemon_name_v6]
   } else {
     $additional_config_path = $bird::additional_config_path_v4
     $validate_cmd = "${bird::v4_path} -p -c ${bird::config_path_v4}"
-    $require = File[$bird::config_path_v4]
+    $require_filepath = File[$bird::config_path_v4]
     $daemon_name = Service[$bird::daemon_name_v4]
   }
   $filepath = "${additional_config_path}/${title}"
@@ -56,7 +56,7 @@ define bird::snippet (
     group        => 'root',
     mode         => '0644',
     validate_cmd => $_validate_cmd,
-    require      => $require,
+    require      => $require_filepath,
   }
   if $bird::manage_service {
     File[$filepath] ~> $daemon_name


### PR DESCRIPTION
when a defined resource uses a `$require` variable, the `require
metaparameter cannot be assigned to the resource. The error is `Cannot
reassign variable '$require'`.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
