### PR TITLE
Fix usage of deprecated ensure_packages / require puppetlabs/stdlib 9

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -150,7 +150,7 @@ class bird (
     Yumrepo['bird'] -> Package <| name == $package_name_v4 or name == $package_name_v6 |>
   }
 
-  ensure_packages([$package_name_v4], { 'ensure' => 'present' })
+  stdlib::ensure_packages([$package_name_v4], { 'ensure' => 'present' })
 
   if $manage_service {
     service { $daemon_name_v4:
@@ -214,7 +214,7 @@ class bird (
       fail('The bird version in Archlinux does not provide a seperate daemon for IPv6. You cannot explicitly enable it. The default daemon already has IPv6 support')
     }
 
-    ensure_packages([$package_name_v6], { 'ensure' => 'present' })
+    stdlib::ensure_packages([$package_name_v6], { 'ensure' => 'present' })
 
     if $manage_service {
       service { $daemon_name_v6:

--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9",
         "10"
       ]
     },

--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     }
   ],
   "requirements": [

--- a/spec/acceptance/bird_spec.rb
+++ b/spec/acceptance/bird_spec.rb
@@ -10,7 +10,7 @@ describe 'bird class' do
       class { 'bird':
         manage_service    => true,
         service_v4_enable => true,
-        enable_v6         => true,
+        enable_v6         => $facts['os']['family'] != 'Archlinux',
         service_v6_enable => true,
         service_v6_ensure => bool2str($facts['os']['family'] == 'RedHat', 'stopped', 'running'),
       }
@@ -32,13 +32,15 @@ describe 'bird class' do
       it { is_expected.to be_running }
     end
 
-    describe service('bird6') do
-      it { is_expected.to be_enabled }
+    if fact('os.family') != 'Archlinux'
+      describe service('bird6') do
+        it { is_expected.to be_enabled }
 
-      if fact('os.family') == 'RedHat'
-        it { is_expected.not_to be_running }
-      else
-        it { is_expected.to be_running }
+        if fact('os.family') == 'RedHat'
+          it { is_expected.not_to be_running }
+        else
+          it { is_expected.to be_running }
+        end
       end
     end
   end


### PR DESCRIPTION
stdlib 9 namespaced functions and depercated the non-namespaced functions.  Puppet 8 raise an error on warning by default, so this fix catalog compilation on some platforms for some configuration when using Puppet 8 and latest stdlib.
